### PR TITLE
Add mocap4ros2 to launcher

### DIFF
--- a/launch_as2.bash
+++ b/launch_as2.bash
@@ -92,7 +92,7 @@ do
 done
 
 if [[ ${estimator_plugin} == "mocap_pose" ]]; then
-  tmuxinator start -n mocap -p utils/mocap.yml &
+  tmuxinator start -n mocap -p utils/mocap4ros2.yml &
   wait
 fi
 

--- a/real_config/cf0_state_estimator.yaml
+++ b/real_config/cf0_state_estimator.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    use_ignition_tf: False
+    rigid_body_name: "1"
+    mocap_topic: "/mocap/rigid_bodies"
+    twist_smooth_filter_cte: 0.1
+    orientation_smooth_filter_cte: 0.1

--- a/real_config/cf1_state_estimator.yaml
+++ b/real_config/cf1_state_estimator.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    use_ignition_tf: False
+    rigid_body_name: "2"
+    mocap_topic: "/mocap/rigid_bodies"
+    twist_smooth_filter_cte: 0.1
+    orientation_smooth_filter_cte: 0.1

--- a/real_config/cf2_state_estimator.yaml
+++ b/real_config/cf2_state_estimator.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    use_ignition_tf: False
+    rigid_body_name: "3"
+    mocap_topic: "/mocap/rigid_bodies"
+    twist_smooth_filter_cte: 0.1
+    orientation_smooth_filter_cte: 0.1

--- a/real_config/optitrack.yaml
+++ b/real_config/optitrack.yaml
@@ -1,0 +1,18 @@
+/**:
+  ros__parameters:
+    connection_type: "Unicast" # Unicast / Multicast
+    server_address: "192.168.40.112"
+    local_address: "0.0.0.0"
+    multicast_address: "239.255.42.99"
+    server_command_port: 1510
+    server_data_port: 1511
+    ### NOT USED ###
+    # rigid_body_name: "ground"
+    # lastFrameNumber: 0
+    # frameCount: 0
+    # droppedFrameCount: 0
+    # n_markers: 0
+    # n_unlabeled_markers: 0
+    # qos_history_policy: "keep_all"         # keep_all / keep_last
+    # qos_reliability_policy: "best_effort"  # best_effort / reliable
+    # qos_depth: 10                         # 10 / 100 / 1000

--- a/utils/mocap4ros2.yml
+++ b/utils/mocap4ros2.yml
@@ -1,0 +1,12 @@
+attach: true
+root: ./
+on_project_start: ". ${HOME}/mocap_ws/install/setup.sh"
+startup_window: mocap
+windows:
+  - mocap:
+      layout:
+      panes:
+        - ros2 launch mocap4r2_optitrack_driver optitrack2.launch.py
+            namespace:=mocap
+            config_file:=real_config/optitrack.yaml
+        - sleep 1; ros2 lifecycle set /mocap/mocap4r2_optitrack_driver_node activate; ros2 topic echo /mocap/rigid_bodies

--- a/utils/session.yml
+++ b/utils/session.yml
@@ -53,7 +53,7 @@ windows:
             namespace:=<%= drone_namespace %>
             use_sim_time:=<%= simulation %>
             plugin_name:=<%= estimator_plugin %>
-            plugin_config_file:=<%= config_path %>/state_estimator.yaml
+            plugin_config_file:=<%= config_path %>/<%= drone_namespace %>_state_estimator.yaml
   - controller:
       layout:
       panes:


### PR DESCRIPTION
Merging this would require some changes in the documentation where we should say that the user have to set another workspace with the MOCAP4ROS2 project.

Also, I'll update soon the project to avoid having one state_estimator config file for each drone. See https://github.com/aerostack2/aerostack2/pull/452
Finally, I think drone_namespace argument in bash launcher doesn't make sense. Namespace for each drone should be the ones at swarm config file (or simulation config file).